### PR TITLE
Add support for the Calendar Service

### DIFF
--- a/Calendar.go
+++ b/Calendar.go
@@ -1,5 +1,9 @@
 package connect
 
+import (
+	"fmt"
+)
+
 // CalendarYear describes a Garmin Connect calendar year
 type CalendarYear struct {
 	StartDayOfJanuary int           `json:"startDayofJanuary"`
@@ -59,4 +63,49 @@ type CalendarItem struct {
 	AutoCalcCalories         bool    `json:"autoCalcCalories"`
 	ProtectedWorkoutSchedule bool    `json:"protectedWorkoutSchedule"`
 	IsParent                 bool    `json:"isParent"`
+}
+
+// CalendarYear will get the activity summaries  and list of days active for a given year
+func (c *Client) CalendarYear(year int) (*CalendarYear, error) {
+	URL := fmt.Sprintf("https://connect.garmin.com/modern/proxy/calendar-service/year/%d",
+		year,
+	)
+	calendarYear := new(CalendarYear)
+	err := c.getJSON(URL, &calendarYear)
+	if err != nil {
+		return nil, err
+	}
+
+	return calendarYear, nil
+}
+
+// CalendarMonth will get the activities for a given month
+func (c *Client) CalendarMonth(year int, month int) (*CalendarMonth, error) {
+	URL := fmt.Sprintf("https://connect.garmin.com/modern/proxy/calendar-service/year/%d/month/%d",
+		year,
+		month-1, // Months in Garmin Connect start from zero
+	)
+	calendarMonth := new(CalendarMonth)
+	err := c.getJSON(URL, &calendarMonth)
+	if err != nil {
+		return nil, err
+	}
+
+	return calendarMonth, nil
+}
+
+// CalendarWeek will get the activities for a given week
+func (c *Client) CalendarWeek(year int, month int, week int) (*CalendarWeek, error) {
+	URL := fmt.Sprintf("https://connect.garmin.com/modern/proxy/calendar-service/year/%d/month/%d/day/%d",
+		year,
+		month-1, // Months in Garmin Connect start from zero
+		week,
+	)
+	calendarWeek := new(CalendarWeek)
+	err := c.getJSON(URL, &calendarWeek)
+	if err != nil {
+		return nil, err
+	}
+
+	return calendarWeek, nil
 }

--- a/Calendar.go
+++ b/Calendar.go
@@ -1,0 +1,62 @@
+package connect
+
+// CalendarYear describes a Garmin Connect calendar year
+type CalendarYear struct {
+	StartDayOfJanuary int           `json:"startDayofJanuary"`
+	LeapYear          bool          `json:"leapYear"`
+	YearItems         []YearItem    `json:"yearItems"`
+	YearSummaries     []YearSummary `json:"yearSummaries"`
+}
+
+// YearItem describes an item on a Garmin Connect calendar year
+type YearItem struct {
+	Date    Date `json:"date"`
+	Display int  `json:"display"`
+}
+
+// YearSummary describes a per-activity-type yearly summary on a Garmin Connect calendar year
+type YearSummary struct {
+	ActivityTypeID     int `json:"activityTypeId"`
+	NumberOfActivities int `json:"numberOfActivities"`
+	TotalDistance      int `json:"totalDistance"`
+	TotalDuration      int `json:"totalDuration"`
+	TotalCalories      int `json:"totalCalories"`
+}
+
+// CalendarMonth describes a Garmin Conenct calendar month
+type CalendarMonth struct {
+	StartDayOfMonth      int            `json:"startDayOfMonth"`
+	NumOfDaysInMonth     int            `json:"numOfDaysInMonth"`
+	NumOfDaysInPrevMonth int            `json:"numOfDaysInPrevMonth"`
+	Month                int            `json:"month"`
+	Year                 int            `json:"year"`
+	CalendarItems        []CalendarItem `json:"calendarItems"`
+}
+
+// CalendarWeek describes a Garmin Connect calendar week
+type CalendarWeek struct {
+	StartDate        Date           `json:"startDate"`
+	EndDate          Date           `json:"endDate"`
+	NumOfDaysInMonth int            `json:"numOfDaysInMonth"`
+	CalendarItems    []CalendarItem `json:"calendarItems"`
+}
+
+// CalendarItem describes an activity displayed on a Garmin Connect calendar
+type CalendarItem struct {
+	ID                       int     `json:"id"`
+	ItemType                 string  `json:"itemType"`
+	ActivityTypeID           int     `json:"activityTypeId"`
+	Title                    string  `json:"title"`
+	Date                     Date    `json:"date"`
+	Duration                 int     `json:"duration"`
+	Distance                 int     `json:"distance"`
+	Calories                 int     `json:"calories"`
+	StartTimestampLocal      Time    `json:"startTimestampLocal"`
+	ElapsedDuration          int     `json:"elapsedDuration"`
+	Strokes                  int     `json:"strokes"`
+	MaxSpeed                 float64 `json:"maxSpeed"`
+	ShareableEvent           bool    `json:"shareableEvent"`
+	AutoCalcCalories         bool    `json:"autoCalcCalories"`
+	ProtectedWorkoutSchedule bool    `json:"protectedWorkoutSchedule"`
+	IsParent                 bool    `json:"isParent"`
+}

--- a/Calendar.go
+++ b/Calendar.go
@@ -56,8 +56,8 @@ type CalendarItem struct {
 	Distance                 int     `json:"distance"`
 	Calories                 int     `json:"calories"`
 	StartTimestampLocal      Time    `json:"startTimestampLocal"`
-	ElapsedDuration          int     `json:"elapsedDuration"`
-	Strokes                  int     `json:"strokes"`
+	ElapsedDuration          float64 `json:"elapsedDuration"`
+	Strokes                  float64 `json:"strokes"`
 	MaxSpeed                 float64 `json:"maxSpeed"`
 	ShareableEvent           bool    `json:"shareableEvent"`
 	AutoCalcCalories         bool    `json:"autoCalcCalories"`
@@ -94,9 +94,9 @@ func (c *Client) CalendarMonth(year int, month int) (*CalendarMonth, error) {
 	return calendarMonth, nil
 }
 
-// CalendarWeek will get the activities for a given week
+// CalendarWeek will get the activities for a given week. A week will be returned that contains the day requested, not starting with)
 func (c *Client) CalendarWeek(year int, month int, week int) (*CalendarWeek, error) {
-	URL := fmt.Sprintf("https://connect.garmin.com/modern/proxy/calendar-service/year/%d/month/%d/day/%d",
+	URL := fmt.Sprintf("https://connect.garmin.com/modern/proxy/calendar-service/year/%d/month/%d/day/%d/start/1",
 		year,
 		month-1, // Months in Garmin Connect start from zero
 		week,

--- a/Client.go
+++ b/Client.go
@@ -196,6 +196,9 @@ func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Re
 	// Play nice and give Garmin engineers a way to contact us.
 	req.Header.Set("User-Agent", "github.com/abrander/garmin-connect")
 
+	// Yep. This is needed for requests sent to the API. No idea what it does.
+	req.Header.Add("nk", "NT")
+
 	c.addCookies(req)
 
 	return req, nil
@@ -236,9 +239,6 @@ func (c *Client) write(method string, url string, payload interface{}, expectedS
 	if err != nil {
 		return err
 	}
-
-	// Yep. This is needed for writing to the API. No idea what it does.
-	req.Header.Add("nk", "NT")
 
 	// If we have a payload it is by definition JSON.
 	if payload != nil {

--- a/connect/calendar.go
+++ b/connect/calendar.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	calendarCmd := &cobra.Command{
+		Use: "calendar",
+	}
+	rootCmd.AddCommand(calendarCmd)
+
+	calendarYearCmd := &cobra.Command{
+		Use:   "year <year>",
+		Short: "List active days in the year",
+		Run:   calendarYear,
+		Args:  cobra.RangeArgs(1, 1),
+	}
+	calendarCmd.AddCommand(calendarYearCmd)
+
+	calendarMonthCmd := &cobra.Command{
+		Use:   "month <year> <month>",
+		Short: "List active days in the month",
+		Run:   calendarMonth,
+		Args:  cobra.RangeArgs(2, 2),
+	}
+	calendarCmd.AddCommand(calendarMonthCmd)
+
+	calendarWeekCmd := &cobra.Command{
+		Use:   "week <year> <month> <day>",
+		Short: "List active days in the week",
+		Run:   calendarWeek,
+		Args:  cobra.RangeArgs(3, 3),
+	}
+	calendarCmd.AddCommand(calendarWeekCmd)
+
+}
+
+func calendarYear(_ *cobra.Command, args []string) {
+	year, err := strconv.ParseInt(args[0], 10, 32)
+	bail(err)
+
+	calendar, err := client.CalendarYear(int(year))
+	bail(err)
+
+	t := NewTable()
+	t.AddHeader("ActivityType ID", "Number of Activities", "Total Distance", "Total Duration", "Total Calories")
+	for _, summary := range calendar.YearSummaries {
+		t.AddRow(
+			summary.ActivityTypeID,
+			summary.NumberOfActivities,
+			summary.TotalDistance,
+			summary.TotalDuration,
+			summary.TotalCalories,
+		)
+	}
+	t.Output(os.Stdout)
+}
+
+func calendarMonth(_ *cobra.Command, args []string) {
+	year, err := strconv.ParseInt(args[0], 10, 32)
+	bail(err)
+
+	month, err := strconv.ParseInt(args[1], 10, 32)
+	bail(err)
+
+	calendar, err := client.CalendarMonth(int(year), int(month))
+	bail(err)
+
+	t := NewTable()
+	t.AddHeader("ID", "Date", "Name", "Distance", "Time", "Calories")
+	for _, item := range calendar.CalendarItems {
+		t.AddRow(
+			item.ID,
+			item.Date,
+			item.Title,
+			item.Distance,
+			item.ElapsedDuration,
+			item.Calories,
+		)
+	}
+	t.Output(os.Stdout)
+}
+
+func calendarWeek(_ *cobra.Command, args []string) {
+	year, err := strconv.ParseInt(args[0], 10, 32)
+	bail(err)
+
+	month, err := strconv.ParseInt(args[1], 10, 32)
+	bail(err)
+
+	week, err := strconv.ParseInt(args[2], 10, 32)
+	bail(err)
+
+	calendar, err := client.CalendarWeek(int(year), int(month), int(week))
+	bail(err)
+
+	t := NewTable()
+	t.AddHeader("ID", "Date", "Name", "Distance", "Time", "Calories")
+	for _, item := range calendar.CalendarItems {
+		t.AddRow(
+			item.ID,
+			item.Date,
+			item.Title,
+			item.Distance,
+			item.ElapsedDuration,
+			item.Calories,
+		)
+	}
+	t.Output(os.Stdout)
+}

--- a/connect/go.mod
+++ b/connect/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/spf13/cobra v1.1.1
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 )
+
+replace github.com/abrander/garmin-connect => ../

--- a/connect/go.mod
+++ b/connect/go.mod
@@ -7,5 +7,3 @@ require (
 	github.com/spf13/cobra v1.1.1
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 )
-
-replace github.com/abrander/garmin-connect => ../


### PR DESCRIPTION
Added support for the Calendar Service. This gives back a summary and list of days with activities for a year. For month and week, it returns a list of activities. I created a new type, as they don't have the same fields as the activity service.