### PR TITLE
Fix double `nk:NT` header in ImportActivity which cause 402 response.

### DIFF
--- a/Activity.go
+++ b/Activity.go
@@ -170,7 +170,7 @@ func (c *Client) ImportActivity(file io.Reader, format ActivityFormat) (int, err
 		return 0, err
 	}
 
-	req.Header.Add("nk", "NT")
+	//req.Header.Add("nk", "NT")
 	req.Header.Add("content-type", writer.FormDataContentType())
 
 	resp, err := c.do(req)


### PR DESCRIPTION
Fix double `nk:NT` header in ImportActivity which cause 402 response.